### PR TITLE
Don't use setTimeout to run the next test loop

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -7,7 +7,7 @@
  */
 ;(function(window, undefined) {
   'use strict';
-
+se
   /** Used to assign each benchmark an incrimented id */
   var counter = 0;
 
@@ -1198,12 +1198,7 @@
     }
     else if (++me.cycles < clone.count) {
       // continue the test loop
-      if (support.timeout) {
-        // use setTimeout to avoid a call stack overflow if called recursively
-        setTimeout(function() { clone.compiled.call(me, timer); }, 0);
-      } else {
-        clone.compiled.call(me, timer);
-      }
+      clone.compiled.call(me, timer);;
     }
     else {
       timer.stop(me);


### PR DESCRIPTION
This code is for preventing stack overflow, but on Chrome this induced 4-5 ms delay for each test run. We need to be careful not to grow stack.
